### PR TITLE
Add option to suppress or override RUBYOPT environment variable

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+=== 1.3.14
+- Add option to suppress or override RUBYOPT environment variable #3 by ccorn90
+
 === 1.3.13
 - Fixed the bug why Innosetup did not run because of missing encode method 
 - Fix an issue where rubyinstaller did not find the msys path by putting in an empty msys-2.0.dll into msys64/usr/bin/msys-2.0.dll

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Executable options:
     --console          Force console application (ruby.exe)  
     --chdir-first      When exe starts, change working directory to app dir.  
     --icon <ico>       Replace icon with a custom one.  
+    --rubyopt <str>    Set the RUBYOPT environment variable when running the executable
     --debug            Executable will be verbose.  
     --debug-extract    Executable will unpack to local dir and not delete after.  
 

--- a/bin/ocran
+++ b/bin/ocran
@@ -187,7 +187,7 @@ module Ocran
     a.sort.inject([]) { |r, e| r.last == e ? r : r << e }
   end
 
-  VERSION = "1.3.13"
+  VERSION = "1.3.14"
 
   IGNORE_MODULE_NAMES = /\/(enumerator.so|rational.so|complex.so|fiber.so|thread.rb|ruby2_keywords.rb)$/
 

--- a/bin/ocran
+++ b/bin/ocran
@@ -230,6 +230,7 @@ module Ocran
     :force_windows => false,
     :force_console => false,
     :icon_filename => nil,
+    :rubyopt => nil,
     :gemfile => nil,
     :inno_script => nil,
     :quiet => false,
@@ -362,6 +363,7 @@ Executable options:
 --console          Force console application (ruby.exe)
 --chdir-first      When exe starts, change working directory to app dir.
 --icon <ico>       Replace icon with a custom one.
+--rubyopt <str>    Set the RUBYOPT environment variable when running the executable
 --debug            Executable will be verbose.
 --debug-extract    Executable will unpack to local dir and not delete after.
 EOF
@@ -393,6 +395,8 @@ EOF
       when /\A--icon\z/
         @options[:icon_filename] = Pathname(argv.shift)
         Ocran.fatal_error "Icon file #{icon_filename} not found.\n" unless icon_filename.exist?
+      when /\A--rubyopt\z/
+        @options[:rubyopt] = argv.shift
       when /\A--gemfile\z/
         @options[:gemfile] = Pathname(argv.shift)
         Ocran.fatal_error "Gemfile #{gemfile} not found.\n" unless gemfile.exist?
@@ -979,7 +983,7 @@ EOF
       sb.createfile((Tempfile.new("msys-2.0.dll")).path.to_s, 'msys64/usr/bin/msys-2.0.dll') unless sb.files.keys.any? { |entry| entry.to_s.include?("msys-2.0.dll") }
 
       # Set environment variable
-      sb.setenv("RUBYOPT", ENV["RUBYOPT"] || "")
+      sb.setenv("RUBYOPT", Ocran.rubyopt || ENV["RUBYOPT"] || "")
       sb.setenv("RUBYLIB", load_path.map { |path| path.to_native }.uniq.join(";"))
 
       sb.setenv("GEM_PATH", (TEMPDIR_ROOT / GEMHOMEDIR).to_native)

--- a/lib/ocran/version.rb
+++ b/lib/ocran/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ocran
-    VERSION = "1.3.13"
+    VERSION = "1.3.14"
   end

--- a/test/test_ocra.rb
+++ b/test/test_ocra.rb
@@ -549,7 +549,7 @@ class TestOcran < MiniTest::Test
     end
   end
 
-  # Test that the RUBYOPT environment variable is preserved.
+  # Test that the RUBYOPT environment variable is preserved when --rubyopt is not passed
   def test_rubyopt
     with_fixture 'environment' do
       with_env "RUBYOPT" => "-rtime" do
@@ -558,6 +558,22 @@ class TestOcran < MiniTest::Test
           assert system("environment.exe")
           env = Marshal.load(File.open("environment", "rb") { |f| f.read })
           assert_equal "-rtime", env['RUBYOPT']
+        end
+      end
+    end
+  end
+
+  # Test that the RUBYOPT environment variable can be set manually with --rubyopt
+  def test_rubyopt_manual
+    specified_rubyopt = "-rbundler --verbose"
+    test_args = DefaultArgs + ["--rubyopt", "'#{specified_rubyopt}'"
+    with_fixture 'environment' do
+      with_env "RUBYOPT" => "-rtime" do
+        assert system("ruby", ocran, "environment.rb", *test_args)
+        pristine_env "environment.exe" do
+          assert system("environment.exe")
+          env = Marshal.load(File.open("environment", "rb") { |f| f.read })
+          assert_equal specified_rubyopt, env['RUBYOPT']
         end
       end
     end


### PR DESCRIPTION
I encountered a situation where this was useful, and I'm hoping others might find that as well.  Important when you want to run `ocran` with one `RUBYOPT` argument list but you'd like the final executable to run with a different set of options (or in my case, no options).