### PR TITLE
Fix for Immediate Closure Issue of ocrantemp.iss File

### DIFF
--- a/bin/ocran
+++ b/bin/ocran
@@ -1179,7 +1179,7 @@ EOF
 
           Ocran.verbose_msg "### INNOSETUP SCRIPT ###\n\n#{iss}\n\n"
 
-          f = File.open("ocrantemp.iss", "w")
+          f = File.open("ocrantemp.iss", "w", autoclose: false)
           f.write(iss)
           f.close()
 


### PR DESCRIPTION
Ruby does not immediately close file descriptors when a File object is closed. This behavior led to ISCC reporting an error, stating that "another process is using the file." By setting the autoclose option to false when opening the file, the File object is closed immediately.

Reference: https://docs.ruby-lang.org/ja/latest/method/IO/i/autoclose=3d.html

The autoclose feature for File objects was added in Ruby 1.9.2, which was released in August 2010.