### PR TITLE
Apply MAX_PATH path and optimize get module file name calls

### DIFF
--- a/bin/ocran
+++ b/bin/ocran
@@ -1006,6 +1006,14 @@ EOF
     # In the Windows API, the maximum length for a path is MAX_PATH, which is defined as 260 characters.
     MAX_PATH = 260
 
+    # The byte size of the buffer given as an argument to the EnumProcessModules function.
+    # This buffer is used to store the handles of the loaded modules.
+    # If the buffer size is smaller than the number of loaded modules,
+    # it will automatically increase the buffer size and call the EnumProcessModules function again.
+    # Increasing the initial buffer size can reduce the number of iterations required.
+    # https://learn.microsoft.com/en-us/windows/win32/psapi/enumerating-all-modules-for-a-process
+    DEFAULT_HMODULE_BUFFER_SIZE = 1024
+
     def LibraryDetector.init_fiddle
       require "fiddle/import"
       require "fiddle/types"
@@ -1029,30 +1037,26 @@ EOF
       init_fiddle
 
       dword = "L" # A DWORD is a 32-bit unsigned integer.
-      bytes_needed = Fiddle::SIZEOF_VOIDP * 32
+      bytes_needed = [0].pack(dword)
+      bytes = DEFAULT_HMODULE_BUFFER_SIZE
       process_handle = GetCurrentProcess()
-      bytes_needed_buffer = [0].pack(dword)
-      while true
-        module_handle_buffer = "\x00" * bytes_needed
-        r = EnumProcessModules(process_handle, module_handle_buffer, module_handle_buffer.bytesize, bytes_needed_buffer)
-        if r == 0
-          errorcode = GetLastError()
-          Ocran.fatal_error "LibraryDetector: EnumProcessModules failed with error code 0x" + errorcode.to_s(16)
-        end
-        bytes_needed = bytes_needed_buffer.unpack1(dword)
-        break if bytes_needed <= module_handle_buffer.bytesize
-      end
-
-      handles = module_handle_buffer.unpack("J#{bytes_needed / Fiddle::SIZEOF_VOIDP}")
+      handles = while true
+                  buffer = "\x00" * bytes
+                  if EnumProcessModules(process_handle, buffer, buffer.bytesize, bytes_needed) == 0
+                    Ocran.fatal_error "LibraryDetector: EnumProcessModules failed with error code %#010x" % GetLastError()
+                  end
+                  bytes = bytes_needed.unpack1(dword)
+                  if bytes <= buffer.bytesize
+                    break buffer.unpack("J#{bytes / Fiddle::SIZEOF_VOIDP}")
+                  end
+                end
       str = "\x00".encode("UTF-16LE") * MAX_PATH
       handles.map do |handle|
-        modulefilename_length = GetModuleFileNameW(handle, str, str.bytesize)
-        if modulefilename_length == 0
-          errorcode = GetLastError()
-          Ocran.fatal_error "LibraryDetector: GetModuleFileNameW failed with error code 0x" + errorcode.to_s(16)
+        length = GetModuleFileNameW(handle, str, str.bytesize)
+        if length == 0
+          Ocran.fatal_error "LibraryDetector: GetModuleFileNameW failed with error code %#010x" % GetLastError()
         end
-        modulefilename = str[0, modulefilename_length].encode("UTF-8")
-        Ocran.Pathname(modulefilename)
+        Ocran.Pathname(str[0, length])
       end
     end
 

--- a/bin/ocran
+++ b/bin/ocran
@@ -1002,6 +1002,10 @@ EOF
   end
 
   module LibraryDetector
+    # https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
+    # In the Windows API, the maximum length for a path is MAX_PATH, which is defined as 260 characters.
+    MAX_PATH = 260
+
     def LibraryDetector.init_fiddle
       require "fiddle"
       require "fiddle/types"
@@ -1059,7 +1063,7 @@ EOF
 
       handles = module_handle_buffer.unpack(f_array)
       handles.select { |handle| handle > 0 }.map do |handle|
-        str = "\x00\x00" * 256
+        str = "\x00\x00" * MAX_PATH
         modulefilename_length = getmodulefilename.call(handle, str, str.size)
         unless modulefilename_length > 0
           errorcode = getlasterror.call()

--- a/bin/ocran
+++ b/bin/ocran
@@ -1065,7 +1065,7 @@ EOF
       str = "\x00".encode("UTF-16LE") * MAX_PATH
       handles.select { |handle| handle > 0 }.map do |handle|
         modulefilename_length = getmodulefilename.call(handle, str, str.bytesize)
-        unless modulefilename_length > 0
+        if modulefilename_length == 0
           errorcode = getlasterror.call
           Ocran.fatal_error "LibraryDetector: GetModuleFileNameW failed with error code 0x" + errorcode.to_s(16)
         end

--- a/bin/ocran
+++ b/bin/ocran
@@ -1043,19 +1043,22 @@ EOF
 
       dword = "L" # A DWORD is a 32-bit unsigned integer.
       bytes_needed = Fiddle::SIZEOF_VOIDP * 32
-      module_handle_buffer = nil
-      process_handle = getcurrentprocess.call()
-      loop do
+      process_handle = getcurrentprocess.call
+      bytes_needed_buffer = [0].pack(dword)
+      while true
         module_handle_buffer = "\x00" * bytes_needed
-        bytes_needed_buffer = [0].pack(dword)
-        r = enumprocessmodules.call(process_handle, module_handle_buffer, module_handle_buffer.size, bytes_needed_buffer)
+        r = enumprocessmodules.call(process_handle, module_handle_buffer, module_handle_buffer.bytesize, bytes_needed_buffer)
+        if r == 0
+          errorcode = getlasterror.call
+          Ocran.fatal_error "LibraryDetector: EnumProcessModules failed with error code 0x" + errorcode.to_s(16)
+        end
         bytes_needed = bytes_needed_buffer.unpack1(dword)
-        break if bytes_needed <= module_handle_buffer.size
+        break if bytes_needed <= module_handle_buffer.bytesize
       end
 
-      handles = module_handle_buffer.unpack("J*")
+      handles = module_handle_buffer.unpack("J#{bytes_needed / Fiddle::SIZEOF_VOIDP}")
       str = "\x00".encode("UTF-16LE") * MAX_PATH
-      handles.select { |handle| handle > 0 }.map do |handle|
+      handles.map do |handle|
         modulefilename_length = getmodulefilename.call(handle, str, str.bytesize)
         if modulefilename_length == 0
           errorcode = getlasterror.call

--- a/bin/ocran
+++ b/bin/ocran
@@ -1041,27 +1041,19 @@ EOF
       getmodulefilename = Fiddle::Function.new(kernel32["GetModuleFileNameW"], [Fiddle::TYPE_UINTPTR_T, Fiddle::TYPE_VOIDP, Fiddle::TYPE_LONG], Fiddle::TYPE_LONG)
       getlasterror = Fiddle::Function.new(kernel32["GetLastError"], [], Fiddle::TYPE_LONG)
 
-# Different packing/unpacking for 64/32 bits systems      
-      if Fiddle::SIZEOF_VOIDP == 8 then
-        f_single = "Q"
-        f_array  = "Q*"
-      else
-        f_single = "I"
-        f_array = "I*"
-      end
-
+      dword = "L" # A DWORD is a 32-bit unsigned integer.
       bytes_needed = Fiddle::SIZEOF_VOIDP * 32
       module_handle_buffer = nil
       process_handle = getcurrentprocess.call()
       loop do
         module_handle_buffer = "\x00" * bytes_needed
-        bytes_needed_buffer = [0].pack(f_single)
+        bytes_needed_buffer = [0].pack(dword)
         r = enumprocessmodules.call(process_handle, module_handle_buffer, module_handle_buffer.size, bytes_needed_buffer)
-        bytes_needed = bytes_needed_buffer.unpack(f_single)[0]
+        bytes_needed = bytes_needed_buffer.unpack1(dword)
         break if bytes_needed <= module_handle_buffer.size
       end
 
-      handles = module_handle_buffer.unpack(f_array)
+      handles = module_handle_buffer.unpack("J*")
       str = "\x00".encode("UTF-16LE") * MAX_PATH
       handles.select { |handle| handle > 0 }.map do |handle|
         modulefilename_length = getmodulefilename.call(handle, str, str.bytesize)

--- a/bin/ocran
+++ b/bin/ocran
@@ -1007,49 +1007,36 @@ EOF
     MAX_PATH = 260
 
     def LibraryDetector.init_fiddle
-      require "fiddle"
+      require "fiddle/import"
       require "fiddle/types"
-      module_eval {
-        extend Fiddle::Importer
-        dlload "psapi.dll"
-        include Fiddle::Win32Types
-        extern "BOOL EnumProcessModules(HANDLE, HMODULE*, DWORD, DWORD*)"
-        extend Fiddle::Importer
-        dlload "kernel32.dll"
-        include Fiddle::Win32Types
 
-# https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types
-# typedef PVOID HANDLE
-# typedef HINSTANCE HMODULE;
+      extend Fiddle::Importer
+      dlload "kernel32.dll", "psapi.dll"
 
-        typealias "HMODULE", "voidp"
-        typealias "HANDLE", "voidp"
-        typealias "LPWSTR", "char*"
+      include Fiddle::Win32Types
+      # https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types
+      typealias "HMODULE", "HINSTANCE"
+      typealias "LPDWORD", "PDWORD"
+      typealias "LPWSTR", "char*"
 
-        extern "DWORD GetModuleFileNameW(HMODULE, LPWSTR, DWORD)"
-        extern "HANDLE GetCurrentProcess(void)"
-        extern "DWORD GetLastError(void)"
-      }
+      extern "BOOL EnumProcessModules(HANDLE, HMODULE*, DWORD, LPDWORD)"
+      extern "DWORD GetModuleFileNameW(HMODULE, LPWSTR, DWORD)"
+      extern "HANDLE GetCurrentProcess()"
+      extern "DWORD GetLastError()"
     end
 
     def LibraryDetector.loaded_dlls
-      require "fiddle"
-      psapi = Fiddle.dlopen("psapi")
-      enumprocessmodules = Fiddle::Function.new(psapi["EnumProcessModules"], [Fiddle::TYPE_UINTPTR_T, Fiddle::TYPE_VOIDP, Fiddle::TYPE_LONG, Fiddle::TYPE_VOIDP], Fiddle::TYPE_LONG)
-      kernel32 = Fiddle.dlopen("kernel32")
-      getcurrentprocess = Fiddle::Function.new(kernel32["GetCurrentProcess"], [], Fiddle::TYPE_LONG)
-      getmodulefilename = Fiddle::Function.new(kernel32["GetModuleFileNameW"], [Fiddle::TYPE_UINTPTR_T, Fiddle::TYPE_VOIDP, Fiddle::TYPE_LONG], Fiddle::TYPE_LONG)
-      getlasterror = Fiddle::Function.new(kernel32["GetLastError"], [], Fiddle::TYPE_LONG)
+      init_fiddle
 
       dword = "L" # A DWORD is a 32-bit unsigned integer.
       bytes_needed = Fiddle::SIZEOF_VOIDP * 32
-      process_handle = getcurrentprocess.call
+      process_handle = GetCurrentProcess()
       bytes_needed_buffer = [0].pack(dword)
       while true
         module_handle_buffer = "\x00" * bytes_needed
-        r = enumprocessmodules.call(process_handle, module_handle_buffer, module_handle_buffer.bytesize, bytes_needed_buffer)
+        r = EnumProcessModules(process_handle, module_handle_buffer, module_handle_buffer.bytesize, bytes_needed_buffer)
         if r == 0
-          errorcode = getlasterror.call
+          errorcode = GetLastError()
           Ocran.fatal_error "LibraryDetector: EnumProcessModules failed with error code 0x" + errorcode.to_s(16)
         end
         bytes_needed = bytes_needed_buffer.unpack1(dword)
@@ -1059,9 +1046,9 @@ EOF
       handles = module_handle_buffer.unpack("J#{bytes_needed / Fiddle::SIZEOF_VOIDP}")
       str = "\x00".encode("UTF-16LE") * MAX_PATH
       handles.map do |handle|
-        modulefilename_length = getmodulefilename.call(handle, str, str.bytesize)
+        modulefilename_length = GetModuleFileNameW(handle, str, str.bytesize)
         if modulefilename_length == 0
-          errorcode = getlasterror.call
+          errorcode = GetLastError()
           Ocran.fatal_error "LibraryDetector: GetModuleFileNameW failed with error code 0x" + errorcode.to_s(16)
         end
         modulefilename = str[0, modulefilename_length].encode("UTF-8")

--- a/bin/ocran
+++ b/bin/ocran
@@ -1062,8 +1062,8 @@ EOF
       end
 
       handles = module_handle_buffer.unpack(f_array)
+      str = "\x00".encode("UTF-16LE") * MAX_PATH
       handles.select { |handle| handle > 0 }.map do |handle|
-        str = "\x00".encode("UTF-16LE") * MAX_PATH
         modulefilename_length = getmodulefilename.call(handle, str, str.bytesize)
         unless modulefilename_length > 0
           errorcode = getlasterror.call

--- a/bin/ocran
+++ b/bin/ocran
@@ -979,8 +979,11 @@ EOF
 
       # Workaround: RubyInstaller cannot find the msys folder if ../msys64/usr/bin/msys-2.0.dll is not present (since RubyInstaller-2.4.1 rubyinstaller 2 issue 23)
       # Add an empty file to /msys64/usr/bin/msys-2.0.dll if the dll was not required otherwise
-      require 'tempfile'
-      sb.createfile((Tempfile.new("msys-2.0.dll")).path.to_s, 'msys64/usr/bin/msys-2.0.dll') unless sb.files.keys.any? { |entry| entry.to_s.include?("msys-2.0.dll") }
+      unless sb.files.keys.any? { |entry| entry.to_s.include?("msys-2.0.dll") }
+        sb.createfile(
+          "share/ocran/empty",
+          "msys64/usr/bin/msys-2.0.dll")
+      end
 
       # Set environment variable
       sb.setenv("RUBYOPT", Ocran.rubyopt || ENV["RUBYOPT"] || "")
@@ -1002,9 +1005,11 @@ EOF
   end
 
   module LibraryDetector
-    # https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
-    # In the Windows API, the maximum length for a path is MAX_PATH, which is defined as 260 characters.
-    MAX_PATH = 260
+    # Windows API functions for handling files may return long paths,
+    # with a maximum character limit of 32,767.
+    # "\\?\" prefix(4 characters) + long path(32762 characters) + NULL = 32767 characters
+    # https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+    MAX_PATH = 32767
 
     # The byte size of the buffer given as an argument to the EnumProcessModules function.
     # This buffer is used to store the handles of the loaded modules.

--- a/bin/ocran
+++ b/bin/ocran
@@ -1063,13 +1063,13 @@ EOF
 
       handles = module_handle_buffer.unpack(f_array)
       handles.select { |handle| handle > 0 }.map do |handle|
-        str = "\x00\x00" * MAX_PATH
-        modulefilename_length = getmodulefilename.call(handle, str, str.size)
+        str = "\x00".encode("UTF-16LE") * MAX_PATH
+        modulefilename_length = getmodulefilename.call(handle, str, str.bytesize)
         unless modulefilename_length > 0
           errorcode = getlasterror.call
           Ocran.fatal_error "LibraryDetector: GetModuleFileNameW failed with error code 0x" + errorcode.to_s(16)
         end
-        modulefilename = str[0, modulefilename_length * 2].force_encoding("UTF-16LE").encode("UTF-8")
+        modulefilename = str[0, modulefilename_length].encode("UTF-8")
         Ocran.Pathname(modulefilename)
       end
     end

--- a/bin/ocran
+++ b/bin/ocran
@@ -1066,7 +1066,7 @@ EOF
         str = "\x00\x00" * MAX_PATH
         modulefilename_length = getmodulefilename.call(handle, str, str.size)
         unless modulefilename_length > 0
-          errorcode = getlasterror.call()
+          errorcode = getlasterror.call
           Ocran.fatal_error "LibraryDetector: GetModuleFileNameW failed with error code 0x" + errorcode.to_s(16)
         end
         modulefilename = str[0, modulefilename_length * 2].force_encoding("UTF-16LE").encode("UTF-8")


### PR DESCRIPTION
I'll send a pull request to fix a minor issue I noticed while reading Ocran's code.

In the loaded_dlls method within the LibraryDetector module, the process of obtaining the path of DLL files using the GetModuleFileNameW function might potentially truncate the retrieved path. In Windows, the maximum path length is defined as MAX_PATH, which is 260 characters. The current implementation limits it to 256 characters.

While Windows allows longer path names, RubyInstaller for Windows doesn't support extended path names, so I defined MAX_PATH as 260 in response.

If there is a future enhancement to support longer path names, we could adjust the MAX_PATH constant to match the maximum path length supported by Windows. However, this would require Windows-based Ruby to support longer path names.

I've made improvements to the code, optimizing the loop that calls the GetModuleFileNameW function and applying the MAX_PATH constant. The buffer string used to receive path names only needs to be created once, so it doesn't consume additional memory with each loop iteration. Additionally, using modulefilename_length for character counting purposes makes the code more readable.

Let me know if you have any questions or suggestions regarding this pull request.