### PR TITLE
Fixed to retrieve the error code from `$?`

### DIFF
--- a/bin/ocran
+++ b/bin/ocran
@@ -1189,7 +1189,7 @@ EOF
           Ocran.msg "Running InnoSetup compiler ISCC"
           result = system(*iscc_cmd)
           if not result
-            case $?
+            case $?.exitstatus
             when 0 then raise RuntimeError.new("ISCC reported success, but system reported error?")
             when 1 then raise RuntimeError.new("ISCC reports invalid command line parameters")
             when 2 then raise RuntimeError.new("ISCC reports that compilation failed")


### PR DESCRIPTION
In Ruby 1.8 and earlier, an integer representing the error code was assigned to `$?`. Starting from Ruby 1.9, it was changed to a `Process::Status` object.
In the current Ruby version, the `case` statement in this part always executes the code under `else`. This was causing incorrect error messages to be displayed to users.

https://bugs.ruby-lang.org/projects/ruby-master/repository/git/revisions/b6de0a6c69a4857ca4347f65d7c9a5cb6e52c5bd

I couldn't find the exact timing of the change in the $? behavior, but based on the information provided in the link, it can be inferred that this bug existed in OCRA (not OCRAN) from Ruby 1.9 onward.

