### PR TITLE
Remove the DeleteOldFiles function from the stub

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+=== 1.3.16
+- At startup, OCRAN no longer automatically removes directories that were previously deployed but couldn't be deleted. This change has been made to enhance security by preventing processes other than the startup process from manipulating temporary files created by them.
+
 === 1.3.15
 - Support for Ruby 2.6 and above.
 - Properly display errors from InnoSetup.


### PR DESCRIPTION
When stub.exe is launched, it searches for files in the temporary directory with the ".ocran-delete-me" prefix and deletes directories by removing the prefix from the found file names. This is a management feature that extends beyond the scope of the application.

The problem with this feature is that it does not distinguish whether the directories meeting the conditions are related to the Ocran application or not:

- By creating files with the ".ocran-delete-me" prefix in the temporary directory, you can induce stub.exe to perform directory deletions in other temporary directories.
- If there are a large number of files with the ".ocran-delete-me" prefix, it increases the processing time of stub.exe.
- Directories that fail to be deleted may continue to fail in subsequent attempts. Ensuring safe and reliable deletion requires confirming that other applications or the OS are not using them, and failure to delete implies that other applications or the OS are using them.
- Running applications should not manipulate directories or files in temporary areas created by others for security reasons. The management of the entire temporary area should follow the policies of the OS and the user.

My proposal is to _'not automatically remove past application extraction directories when stub.exe is launched.'_

Stub.exe sets the 'MOVEFILE_DELAY_UNTIL_REBOOT' flag on files that could not be deleted. This flag causes Windows to automatically delete the files upon a Windows restart. Therefore, even with this code change, the automatic file deletion feature will still be in place. My code change is to prevent Ocran from actively performing automatic removal.