### PR TITLE
Drop ruby 2.6 and 2.7 support

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,5 @@
 === 1.3.16
+- Support for Ruby 3.0 and above. Drop ruby 2.6 and 2.7 support.
 - At startup, OCRAN no longer automatically removes directories that were previously deployed but couldn't be deleted. This change has been made to enhance security by preventing processes other than the startup process from manipulating temporary files created by them.
 - The ability for the stub to launch any script during the unpacking of application files has been removed. This feature was not in use.
 - The exit code from the Ruby application is now returned when the stub is terminated.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ executable that contains the Ruby interpreter, your source code and
 any additionally needed ruby libraries or DLL.
 
 OCRAN is a fork of Ocra (https://github.com/larsch/ocra) in order to
-maintain compatibility with newer Ruby versions after 2.6
+maintain compatibility with newer Ruby versions after 3.0
 
 ## Recommended usage
 Most commonly you will needs this, when you want to ship your program to windows servers / users that don't have Ruby installed.

--- a/ocran.gemspec
+++ b/ocran.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description = "OCRAN (One-Click Ruby Application Next) builds Windows executables from Ruby source code. 
   The executable is a self-extracting, self-running executable that contains the Ruby interpreter, your source code and any additionally needed ruby libraries or DLL.
   
-  This is a fork of OCRA that is compatible with ruby version after 2.6. 
+  This is a fork of OCRA that is compatible with ruby version after 3.0.
   Migration guide: make sure to write ocran instead of ocra in your code. For instance: OCRAN_EXECUTABLE
 
   usage: 
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   This gem contains executables. We plan to build them on github actions for security.
   "
   spec.homepage = "https://github.com/largo/ocran"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/largo/ocran"


### PR DESCRIPTION
https://github.com/Largo/ocran/issues/17
We want to test against all versions of Ruby that we support. In addition, the gems 'minitest' and 'hoe', which are required by OCRAN, will also end their support for Ruby 2.x in the near future.