### PR TITLE
Discontinue ocransa (Ocran-stand-alone)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 *.exe
 *.gem
 !/share/ocran/lzma.exe
-bin/ocransa.rb
 pkg
 README.txt
-ocransa-*.zip
 *.tmp

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@
 - Update Bundler from 2.4.13 to 2.5.10.
 - Fixed issue where the gem.build_complete file was not included in the package due to an incorrect change.
 - Changed error output from standard output to standard error (stderr).
+- ocransa (Ocran-stand-alone) has been discontinued.
 
 === 1.3.15
 - Support for Ruby 2.6 and above.

--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ Alternatively you can download the gem at either
 http://rubygems.org/gems/ocran or
 https://github.com/largo/ocran/releases/.
 
-Stand-alone Version: Get ocransa.rb from
-https://github.com/largo/ocran/releases/. Requires nothing but a
-working Ruby installation on Windows.
-
 ## Synopsis
 
 ### Building an executable:
@@ -178,11 +174,6 @@ Executable options:
 * Windows
 * Working Ruby installation.
 * Ruby Installation with devkit from rubyinstaller (when working with the source code only)
-
-### Stand-alone version
-
-Get ocransa.rb from the github releases. Requires
-nothing but a working Ruby installation on Windows. (currently not supported - open an issue if you need this)
 
 ## Technical details
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,58 +25,10 @@ file "share/ocran/edicon.exe" => :build_stub
 
 task :test => :build_stub
 
-task :standalone => ["exe/ocrasa.rb"]
-
-standalone_zip = "exe/ocrasa-#{ENV["VERSION"]}.zip"
-
-file standalone_zip => "exe/ocrasa.rb" do
-  chdir "exe" do
-    sh "zip", "ocransa-#{ENV["VERSION"]}.zip", "ocransa.rb"
-  end
-end
-
-task :release_standalone => standalone_zip do
-  load "bin/ocran"
-  #sh "rubyforge add_release ocran ocran-standalone #{Ocran::VERSION} #{standalone_zip}"
-end
-
-file "bin/ocrasa.rb" => ["bin/ocra", "share/ocran/stub.exe", "share/ocran/stubw.exe", "share/ocran/lzma.exe", "share/ocran/edicon.exe"] do
-  cp "bin/ocran", "bin/ocrasa.rb"
-  File.open("bin/ocrasa.rb", "a") do |f|
-    f.puts "__END__"
-
-    stub = File.open("share/ocran/stub.exe", "rb") { |g| g.read }
-    stub64 = [stub].pack("m")
-    f.puts stub64.size
-    f.puts stub64
-
-    stub = File.open("share/ocran/stubw.exe", "rb") { |g| g.read }
-    stub64 = [stub].pack("m")
-    f.puts stub64.size
-    f.puts stub64
-
-    lzma = File.open("share/ocran/lzma.exe", "rb") { |g| g.read }
-    lzma64 = [lzma].pack("m")
-    f.puts lzma64.size
-    f.puts lzma64
-
-    lzma = File.open("share/ocran/edicon.exe", "rb") { |g| g.read }
-    lzma64 = [lzma].pack("m")
-    f.puts lzma64.size
-    f.puts lzma64
-  end
-end
-
 task :clean do
   rm_f Dir["{bin,samples}/*.exe"]
   rm_f Dir["share/ocran/{stub,stubw,edicon}.exe"]
   sh "ridk exec make -C src clean"
-end
-
-task :test_standalone => :standalone do
-  ENV["TESTED_OCRAN"] = "ocransa.rb"
-  system("rake test")
-  ENV["TESTED_OCRAN"] = nil
 end
 
 task :release_docs => :redocs do


### PR DESCRIPTION
The implementation of bin/ocran.rb has been split into multiple files, making it impossible to release a stand-alone version.