### PR TITLE
Move ocran.rb from bin to exe directory and update file settings

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "ocran"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/exe/ocran
+++ b/exe/ocran
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# encoding: UTF-8
+# frozen_string_literal: true
 
 load File.expand_path("../lib/ocran/runner.rb", __dir__)
 load Ocran::Runner.new.run

--- a/ocran.gemspec
+++ b/ocran.gemspec
@@ -39,8 +39,8 @@ Gem::Specification.new do |spec|
     #       (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|circleci)|appveyor)})
     #     end
     #   end
-  spec.files = Dir.glob("bin/ocran") + Dir.glob("lib/**/**")  + Dir.glob("share/ocran/**") 
-  spec.bindir = "bin"
+  spec.files = Dir.glob("exe/ocran") + Dir.glob("lib/**/**")  + Dir.glob("share/ocran/**")
+  spec.bindir = "exe"
   spec.executables = %w[ocran]
   spec.require_paths = ["lib"]
 

--- a/test/test_ocra.rb
+++ b/test/test_ocra.rb
@@ -59,7 +59,7 @@ class TestOcran < Minitest::Test
 
   def initialize(*args)
     super(*args)
-    @ocran = File.expand_path(File.join(File.dirname(__FILE__), '..', 'bin', TESTED_OCRAN))
+    @ocran = File.expand_path(File.join(File.dirname(__FILE__), '..', 'exe', TESTED_OCRAN))
     ENV['RUBYOPT'] = ""
   end
 


### PR DESCRIPTION
This commit relocates the ocran.rb command script from the bin directory to the exe directory, aligning with the standard structure for Ruby gems. Additionally, the encoding comment has been removed as UTF-8 is the default setting. Also, `# frozen_string_literal: true` was added to adopt a standard practice in Ruby implementation.