### PR TITLE
Make the POSIX stub compile with cosmocc and add a porting plan

### DIFF
--- a/docs/cosmocc-port-plan.md
+++ b/docs/cosmocc-port-plan.md
@@ -1,0 +1,140 @@
+# Compiling the OCRAN stub with cosmocc (Cosmopolitan Libc)
+
+Status: **experimental — the POSIX stub already compiles and passes an
+end-to-end smoke test with cosmocc**. Tracking issue:
+[#26](https://github.com/largo/ocran/issues/26).
+
+## Goal
+
+Long-term, make the launcher stub buildable against
+[Cosmopolitan Libc](https://github.com/jart/cosmopolitan) (`cosmocc`), so
+it can be maintained against a POSIX-style API surface instead of raw
+Win32, and so a single Actually Portable Executable (APE) stub could in
+principle run on Windows, Linux and macOS.
+
+## Where we already are
+
+The stub was modularized some time ago and the Win32 surface is already
+isolated behind one backend file:
+
+| File | Role |
+|------|------|
+| `src/stub.c` | `main()` — platform-neutral, calls only the `system_utils.h` API |
+| `src/system_utils.h` | Platform abstraction API (paths, mmap, process, env, signals) |
+| `src/system_utils.c` | **Windows backend** (mingw build) |
+| `src/system_utils_posix.c` | **POSIX backend** (Linux/macOS build; also the cosmocc target) |
+| `src/unpack.c` | Opcode parsing; small `#ifdef _WIN32` islands (Authenticode/PE handling) |
+| `src/inst_dir.c` | Extraction dir; symlink support guarded `#ifndef _WIN32` |
+| `src/error.c` / `error.h` | Logging; `MessageBox` only in the `_WIN32` GUI (`stubw`) build |
+| `src/Makefile` | Selects backend by `uname`; POSIX hosts build a native `stub` |
+
+So "port stub.c to POSIX" is essentially done; the cosmocc question
+reduces to "does the POSIX backend compile and run under Cosmopolitan?"
+
+## Win32 API inventory (the mingw backend, `system_utils.c`)
+
+For reference, the Windows-only API surface that the POSIX backend
+replaces:
+
+| Win32 API | Purpose | POSIX / Cosmopolitan equivalent |
+|-----------|---------|--------------------------------|
+| `CreateFileW` / `CreateFileMappingW` / `MapViewOfFile` | map own exe | `open` + `mmap` (works under cosmo) |
+| `GetModuleFileNameW` | own exe path | `/proc/self/exe` (Linux), `_NSGetExecutablePath` (macOS), **`GetProgramExecutableName()` (cosmo)** |
+| `GetTempPathW` | temp dir | `$TMPDIR` else `/tmp` (cosmo maps `/tmp` to the host temp dir on Windows) |
+| `CreateDirectoryW` / `DeleteFileW` / `RemoveDirectoryW` / `FindFirstFileW`… | dir tree create/delete | `mkdir` / `unlink` / `rmdir` / `opendir`+`readdir` |
+| `BCryptGenRandom` | unique temp dir name | `mkdtemp` |
+| `CreateProcessW` + `WaitForSingleObject` + `GetExitCodeProcess` | launch ruby | `fork` + `execv` + `waitpid` (cosmo emulates via `CreateProcess` on Windows) |
+| `SetEnvironmentVariableW` | env vars | `setenv` / `unsetenv` |
+| `SetConsoleCtrlHandler` | ignore Ctrl-C during cleanup | `sigaction(SIGINT/SIGTERM, SIG_IGN)` |
+| `GetLongPathNameW` | 8.3-name normalization | not needed on POSIX (`ToLongPath` = `strdup`) |
+| `WideCharToMultiByte` / `MultiByteToWideChar` | UTF-8 ↔ UTF-16 | not needed (cosmo is UTF-8 throughout, converts internally on Windows) |
+| `MessageBox` (error.c, `stubw` only) | GUI fatal errors | stderr only (no GUI stub under cosmo) |
+| `IMAGE_NT_HEADERS` walk (unpack.c) | find OCRAN signature in Authenticode-signed exes | not compiled; POSIX branch scans signature at EOF |
+
+## Cosmocc findings (cosmocc 14.1.0 / GCC 14.1.0, 2025-01-05 toolchain)
+
+Baseline attempt: `make -C src CC=cosmocc` (GNU make command-line
+variables already override the Makefile's `CC := gcc`, so no Makefile
+change was needed for this).
+
+**Exactly one compile error** in the whole tree:
+
+```
+system_utils_posix.c:380:2: error: #error "GetImagePath not implemented for this platform"
+```
+
+Cause: cosmocc defines `__COSMOPOLITAN__`/`__COSMOCC__` but deliberately
+*neither* `__linux__` nor `__APPLE__` (an APE binary decides its host OS
+at run time, not compile time), so `GetImagePath()` fell through to the
+`#error` branch. Everything else — `mmap`, `mkdtemp`, `sigaction`,
+`fork`/`execv`/`waitpid`, `dirent`, LZMA — compiled warning-free.
+
+Fix (in this branch): `GetImagePath()` gained a `__COSMOPOLITAN__`
+branch that uses `GetProgramExecutableName()` from `<cosmo.h>`, which
+resolves the executable path on every OS the APE runs on.
+
+### Verification performed
+
+* `make -C src` (native gcc, Linux): builds `stub` (ELF), unchanged
+  behavior.
+* `make -C src CC=cosmocc`: builds `stub` as an APE (~700 KB), zero
+  warnings.
+* End-to-end smoke test on Linux for **both** binaries: appended a
+  hand-packed payload (modes byte `DEBUG|AUTO_CLEAN_INST_DIR`,
+  `OP_CREATE_FILE` of a shell script, `OP_SETENV`, `OP_SET_SCRIPT`,
+  offset + OCRAN signature). Both stubs extracted to a fresh
+  `$TMPDIR/ocranXXXXXX` dir, launched the app, propagated its exit code
+  (42), and auto-cleaned the extraction dir.
+
+## Build integration
+
+* Today: `make -C src CC=cosmocc` with `cosmocc` on `PATH`
+  (single ~440 MB zip from <https://cosmo.zip/pub/cosmocc/cosmocc.zip>).
+* CI sketch (phase 1): a Linux job that caches the pinned cosmocc zip,
+  builds `src` with `CC=cosmocc`, and runs the existing POSIX test path
+  against the APE stub. The mingw/RubyInstaller jobs stay untouched —
+  cosmocc is an *additional* backend, not a replacement.
+
+## Risks / open questions
+
+1. **APE file format vs. appended payload.** An APE is itself a
+   PE/shell-script/ZIP polyglot; OCRAN appends its payload after EOF.
+   This works on Linux (verified: the EOF signature scan finds the
+   payload). On Windows the APE executes as a plain PE, and PE overlays
+   are legal, but interaction with the APE ZIP store / `zipos` and with
+   `apelink`/`--assimilate` needs explicit testing before trusting it.
+2. **Launching Windows Ruby from an APE stub.** The POSIX backend uses
+   `fork`+`execv`; Cosmopolitan emulates these on Windows via
+   `CreateProcess`, but argument quoting, `.exe` resolution and console
+   inheritance must be verified against a real packed `ruby.exe`.
+3. **No GUI stub.** `stubw` (`-mwindows` + `MessageBox`) has no cosmo
+   equivalent; an APE on Windows is always a console-subsystem binary.
+   cosmocc can stay console-only (`stub`), with mingw continuing to
+   provide `stubw`.
+4. **Code signing.** The Authenticode-aware signature search is compiled
+   only under `_WIN32`. A cosmocc stub that gets Authenticode-signed on
+   Windows would need that logic ported (guard on the PE magic at run
+   time rather than `#ifdef`).
+5. **Temp/paths on Windows.** POSIX `GetTempDirectoryPath()` returns
+   `$TMPDIR` else `/tmp`; Cosmopolitan translates `/tmp` to the host
+   temp dir on Windows, and handles UTF-8→UTF-16 path conversion, but
+   8.3 short-name normalization (`ToLongPath`) is a no-op — the
+   `$LOADED_FEATURES` dedup issue it works around on mingw would need a
+   runtime check if the APE stub ever targets Windows.
+6. **Toolchain pinning.** cosmocc releases move fast; CI must pin an
+   exact toolchain version.
+
+## Milestones
+
+* **Phase 0 (this branch)** — `make CC=cosmocc` compiles and links;
+  `GetImagePath()` has a `__COSMOPOLITAN__` implementation; smoke test
+  passes on Linux; this document.
+* **Phase 1** — CI job building the stub with a pinned cosmocc and
+  running the POSIX smoke/test suite against the APE artifact on Linux.
+* **Phase 2** — Exercise the packed APE stub on Windows and macOS
+  runners: payload discovery (risk 1), process launch of a real packed
+  Ruby (risk 2), temp-dir semantics (risk 5).
+* **Phase 3** — Decide the product story: keep cosmocc as a
+  cross-platform *console* stub built from POSIX sources (mingw keeps
+  `stubw` + signing), or go further and make the APE stub a first-class
+  packaging target (requires resolving risks 1–5).

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,9 @@
 # Detect host OS
+#
+# Experimental: the POSIX stub also builds with Cosmopolitan Libc
+# (https://github.com/jart/cosmopolitan) into an Actually Portable
+# Executable:  make CC=cosmocc
+# See ../docs/cosmocc-port-plan.md for status and caveats.
 UNAME           := $(shell uname -s 2>/dev/null || echo Windows)
 IS_POSIX        := $(filter $(UNAME),Linux Darwin)
 
@@ -67,6 +72,10 @@ endif
 clean:
 	rm -f $(BINARIES) $(COMMON_OBJS) $(CONSOLE_OBJS) $(WINDOW_OBJS) \
 	      $(RESOURCE_OBJ)
+	# cosmocc (CC=cosmocc) byproducts
+	rm -f $(addsuffix .com.dbg, $(PROG_NAMES)) \
+	      $(addsuffix .aarch64.elf, $(PROG_NAMES))
+	rm -rf .aarch64 lzma/.aarch64
 
 install: $(BINARIES)
 	mkdir -p $(BINDIR)

--- a/src/system_utils_posix.c
+++ b/src/system_utils_posix.c
@@ -1,6 +1,9 @@
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
+#ifdef __COSMOPOLITAN__
+#include <cosmo.h>  /* GetProgramExecutableName() */
+#endif
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -360,6 +363,23 @@ bool ExportFile(const char *path, const void *buffer, size_t buffer_size) {
 /* ===== Path utilities ===== */
 
 char *GetImagePath(void) {
+#ifdef __COSMOPOLITAN__
+    /* Cosmopolitan Libc defines neither __linux__ nor __APPLE__; it resolves
+       the executable path itself on every OS the APE binary runs on. */
+    const char *exe = GetProgramExecutableName();
+    if (!exe || !*exe) {
+        FATAL("GetImagePath: GetProgramExecutableName failed");
+        return NULL;
+    }
+
+    char *result = strdup(exe);
+    if (!result) {
+        FATAL("GetImagePath: strdup failed");
+        return NULL;
+    }
+
+    return result;
+#else
     static char path_buffer[4096];
 #ifdef __APPLE__
     uint32_t size = sizeof(path_buffer);
@@ -388,6 +408,7 @@ char *GetImagePath(void) {
 
     strcpy(result, path_buffer);
     return result;
+#endif /* __COSMOPOLITAN__ */
 }
 
 char *GetTempDirectoryPath(void) {


### PR DESCRIPTION
Addresses #26.

## Key finding
The stub has already evolved past the issue's premise: it's modularized with a Win32 backend (`src/system_utils.c`) and a POSIX backend (`src/system_utils_posix.c`), selected by `uname` in `src/Makefile`. Compiling with the real cosmocc toolchain (14.1.0) surfaced **exactly one error** in the whole tree: cosmocc defines `__COSMOPOLITAN__` but neither `__linux__` nor `__APPLE__`, so `GetImagePath()` fell through to `#error`.

## Changes
- `src/system_utils_posix.c`: add a `__COSMOPOLITAN__` branch to `GetImagePath()` using `GetProgramExecutableName()` from `<cosmo.h>`; existing Linux/macOS branches untouched.
- `src/Makefile`: document `make CC=cosmocc` (command-line `CC=` already overrides the default, no build-logic change); `clean` also removes cosmocc byproducts (`*.com.dbg`, `*.aarch64.elf`, `.aarch64/`).
- `docs/cosmocc-port-plan.md`: full Win32 API inventory of the mingw backend, POSIX/cosmopolitan equivalence table, CI integration sketch, risks, and phased milestones.

## Testing
- Native `make -C src` (gcc 14, Linux): unchanged, builds the ELF stub.
- `make -C src CC=cosmocc`: builds a ~700 KB APE binary with zero warnings.
- End-to-end for **both** binaries: hand-packed a real OCRAN payload (modes byte, OP_CREATE_FILE, OP_SETENV, OP_SET_SCRIPT, offset + signature) onto each stub; both extract to `$TMPDIR/ocranXXXXXX`, launch the app, propagate exit code, and clean up.

## Known limitations (detailed in the plan doc)
APE-overlay vs appended payload on Windows needs testing (APE is a PE/ZIP polyglot); cosmo `fork`/`execv` emulation with a real packed `ruby.exe` unverified; no GUI `stubw` equivalent; Authenticode-aware signature search only compiles under `_WIN32`; `ToLongPath` is a no-op in the POSIX backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)