### PR TITLE
Add --cosmo option: build the launcher stub with cosmocc at packaging time

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+=== Unreleased
+- New experimental `--cosmo <path>` option (alias `--cosmo-toolchain`): build the launcher stub from its C sources with a Cosmopolitan Libc toolchain (cosmocc) at packaging time and package the application with the resulting Actually Portable Executable (APE) stub instead of the pre-built stub (issue #26). `<path>` is the cosmocc executable or the toolchain directory (containing bin/cosmocc). Console applications only (`--windows` is rejected); requires make and a Linux/macOS build host. The default output name uses the `.com` extension (APE convention); an explicit `--output` is used verbatim. Compiled stubs are cached in ~/.cache/ocran keyed on the toolchain and stub sources; compile errors surface the compiler output.
+- Ship the stub C sources (src/) in the binary platform gems so `--cosmo` can rebuild the stub from an installed gem, not only from a source checkout.
+
 === 1.4.4
 - Fix crash on distro-packaged and Homebrew Ruby when a default gem (e.g. fiddle, singleton) has a gemspec but no materialized gem directory: file collection now treats the missing directory as an empty set instead of raising Errno::ENOENT from Find.find (issue #44). The gem's files, which live in the stdlib, are still packed via the load path.
 - Pack the real Ruby interpreter when bindir/ruby is a dispatcher script (e.g. Fedora's rubypick): the running interpreter binary (/proc/self/exe) is packed under the expected name instead, so the packed executable no longer requires Ruby on the target system.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,30 @@ Fine-tuning flags:
 * `--debug`: Enable verbose output when the generated executable runs.
 * `--debug-extract`: Unpack to a local directory and do not delete after execution (useful for troubleshooting).
 
+#### Experimental options:
+
+* `--cosmo <path>` (alias `--cosmo-toolchain`): Build the launcher stub
+  from its C sources with a
+  [Cosmopolitan Libc](https://github.com/jart/cosmopolitan) `cosmocc`
+  toolchain at packaging time, and package the application with the
+  resulting Actually Portable Executable (APE) stub instead of the
+  pre-built stub shipped with the gem. `<path>` is either the `cosmocc`
+  executable itself or the toolchain directory (one containing
+  `bin/cosmocc`, e.g. an unpacked
+  [cosmocc.zip](https://cosmo.zip/pub/cosmocc/cosmocc.zip)).
+  Notes:
+  * Requires `make` and a Linux/macOS build host; console applications
+    only (`--windows` is rejected — cosmocc has no GUI `stubw`
+    equivalent).
+  * The default output name uses the `.com` extension (APE convention),
+    e.g. `script.rb` → `script.com`; an explicit `--output` is used
+    verbatim.
+  * Compiled stubs are cached in `~/.cache/ocran` (keyed on the
+    toolchain and stub sources), so only the first build compiles.
+  * The packaged Ruby runtime is still the host platform's Ruby — the
+    APE property currently applies to the launcher stub, not to the
+    bundled application. See `docs/cosmocc-port-plan.md` for status.
+
 ### Compilation:
 
 * OCRAN runs your script (using `Kernel#load`) and builds the output when it exits.

--- a/docs/cosmocc-port-plan.md
+++ b/docs/cosmocc-port-plan.md
@@ -88,7 +88,16 @@ resolves the executable path on every OS the APE runs on.
 
 ## Build integration
 
-* Today: `make -C src CC=cosmocc` with `cosmocc` on `PATH`
+* **Build-at-packaging-time (implemented):** `ocran script.rb --cosmo
+  <path-to-toolchain>` compiles the stub sources with the given cosmocc
+  during the packaging run and packages the app with the fresh APE stub
+  (default output extension `.com`). Implementation:
+  `lib/ocran/cosmo_toolchain.rb` (path resolution, compile via `make -C
+  src stub CC=cosmocc` in a temp copy of `src/`, compiler output
+  surfaced on failure, results cached in `~/.cache/ocran` keyed on
+  toolchain + source hash). The binary platform gems now ship `src/` so
+  this works from an installed gem, not just a checkout.
+* Manual: `make -C src CC=cosmocc` with `cosmocc` on `PATH`
   (single ~440 MB zip from <https://cosmo.zip/pub/cosmocc/cosmocc.zip>).
 * CI sketch (phase 1): a Linux job that caches the pinned cosmocc zip,
   builds `src` with `CC=cosmocc`, and runs the existing POSIX test path
@@ -126,9 +135,16 @@ resolves the executable path on every OS the APE runs on.
 
 ## Milestones
 
-* **Phase 0 (this branch)** — `make CC=cosmocc` compiles and links;
+* **Phase 0 (done)** — `make CC=cosmocc` compiles and links;
   `GetImagePath()` has a `__COSMOPOLITAN__` implementation; smoke test
   passes on Linux; this document.
+* **Phase 0.5 (done — runtime build)** — build the stub with cosmocc at
+  packaging time: the `--cosmo <toolchain>` command-line option compiles
+  `src/` with the user's toolchain and packages with the resulting APE
+  stub (console only, `.com` default extension, stub cache in
+  `~/.cache/ocran`); end-to-end test `test_cosmo_helloworld` (skipped
+  unless a cosmocc toolchain is found via `COSMOCC` or `PATH`) builds
+  and runs a packed app on Linux.
 * **Phase 1** — CI job building the stub with a pinned cosmocc and
   running the POSIX smoke/test suite against the APE artifact on Linux.
 * **Phase 2** — Exercise the packed APE stub on Windows and macOS

--- a/lib/ocran/cosmo_toolchain.rb
+++ b/lib/ocran/cosmo_toolchain.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+require "digest"
+require "fileutils"
+require "tmpdir"
+
+module Ocran
+  # Builds the launcher stub from the C sources in src/ with a
+  # Cosmopolitan Libc toolchain (cosmocc, https://cosmo.zip) at packaging
+  # time, producing an Actually Portable Executable (APE) stub that is
+  # used instead of the pre-built native stub shipped with the gem.
+  #
+  # Activated with the --cosmo (alias: --cosmo-toolchain) command line
+  # option. See docs/cosmocc-port-plan.md for background and caveats.
+  module CosmoToolchain
+    # Stub C sources shipped with the gem (also included in the binary
+    # platform gems specifically so this feature works from an installed gem).
+    SRC_DIR = File.expand_path("../../src", __dir__)
+
+    module_function
+
+    # Resolves the path given on the command line to the cosmocc compiler
+    # driver. Accepts either the cosmocc executable itself, the toolchain
+    # installation directory (containing bin/cosmocc), or its bin directory.
+    # Returns the absolute path to cosmocc; raises with a clear message
+    # when nothing usable is found.
+    def resolve_cc(path)
+      if path.nil? || path.to_s.empty?
+        raise "--cosmo requires a path to a cosmocc toolchain (the cosmocc executable or its installation directory)"
+      end
+
+      path = File.expand_path(path.to_s)
+
+      candidates =
+        if File.directory?(path)
+          [File.join(path, "bin", "cosmocc"), File.join(path, "cosmocc")]
+        else
+          [path]
+        end
+
+      cc = candidates.find { |c| File.file?(c) }
+      unless cc
+        raise "cosmocc not found at #{path} (expected the cosmocc executable itself, or a toolchain directory containing bin/cosmocc)"
+      end
+      unless File.executable?(cc)
+        raise "cosmocc found at #{cc} but it is not executable"
+      end
+      cc
+    end
+
+    # Compiles the stub sources with the given cosmocc and returns the
+    # path to the resulting APE stub binary. Results are cached in the
+    # user cache directory, keyed on the toolchain and the stub sources,
+    # so repeated packaging runs do not recompile. On compile failure the
+    # compiler output is included in the raised error.
+    def build_stub(cc)
+      if Gem.win_platform?
+        raise "--cosmo is not supported when building on Windows (build the APE stub on a Linux/macOS host)"
+      end
+      unless system("command -v make > /dev/null 2>&1")
+        raise "make not found in PATH (required to build the stub with cosmocc)"
+      end
+      unless File.directory?(SRC_DIR)
+        raise "stub sources not found at #{SRC_DIR} (cannot build with cosmocc)"
+      end
+
+      cached = File.join(cache_dir, "stub-#{cache_key(cc)}")
+      return cached if File.file?(cached)
+
+      Dir.mktmpdir("ocran-cosmo") do |tmp|
+        build_dir = File.join(tmp, "src")
+        FileUtils.cp_r(SRC_DIR, build_dir)
+        log = File.join(tmp, "make.log")
+        # A development checkout may contain native build artifacts
+        # (.o files, stub) that cp_r copied along — clean them so the
+        # stub is fully rebuilt with cosmocc.
+        system("make", "-C", build_dir, "clean", { [:out, :err] => IO::NULL })
+        ok = system("make", "-C", build_dir, "stub", "CC=#{cc}",
+                    { [:out, :err] => log })
+        unless ok
+          output = File.exist?(log) ? File.read(log) : "(no build output captured)"
+          raise "Failed to build the stub with cosmocc (make -C src stub CC=#{cc}):\n#{output}"
+        end
+        FileUtils.mkdir_p(File.dirname(cached))
+        FileUtils.cp(File.join(build_dir, "stub"), cached)
+        File.chmod(0755, cached)
+      end
+      cached
+    end
+
+    # Cache key covering the toolchain (path, mtime, size — so an updated
+    # toolchain at the same path recompiles) and every stub source file.
+    def cache_key(cc)
+      digest = Digest::SHA256.new
+      stat = File.stat(cc)
+      digest << cc << stat.mtime.to_i.to_s << stat.size.to_s
+      Dir.glob("**/*", base: SRC_DIR).sort.each do |rel|
+        abs = File.join(SRC_DIR, rel)
+        next unless File.file?(abs)
+        digest << rel << File.binread(abs)
+      end
+      digest.hexdigest[0, 16]
+    end
+
+    def cache_dir
+      base = ENV["XDG_CACHE_HOME"]
+      base = File.join(Dir.home, ".cache") if base.nil? || base.empty?
+      File.join(base, "ocran")
+    rescue ArgumentError # Dir.home unavailable (no HOME)
+      File.join(Dir.tmpdir, "ocran-cache")
+    end
+  end
+end

--- a/lib/ocran/direction.rb
+++ b/lib/ocran/direction.rb
@@ -762,6 +762,23 @@ module Ocran
       say "Finished building installer file"
     end
 
+    # Returns the path to the stub built from source with cosmocc when
+    # --cosmo was given, or nil to use the pre-built stub shipped with
+    # the gem. The build result is memoized (and CosmoToolchain caches
+    # compiled stubs across runs), so multiple stubs per build (e.g.
+    # wrapper executables) compile at most once.
+    def cosmo_stub_path
+      return nil unless @option.cosmo_cc
+
+      @cosmo_stub_path ||= begin
+        require_relative "cosmo_toolchain"
+        say "Building launcher stub from source with cosmocc (#{@option.cosmo_cc})"
+        path = CosmoToolchain.build_stub(@option.cosmo_cc)
+        say "Using APE stub #{path}"
+        path
+      end
+    end
+
     # Builds the small RUN_IN_EXE_DIR wrapper stub that starts the deployed
     # application directly from the directory the wrapper resides in.
     def build_wrapper_exe(wrapper_path)
@@ -772,7 +789,8 @@ module Ocran
                       debug_mode: @option.enable_debug_mode?,
                       gui_mode: @option.windowed?,
                       icon_path: @option.icon_filename,
-                      run_in_exe_dir: true) do |stub|
+                      run_in_exe_dir: true,
+                      stub_path: cosmo_stub_path) do |stub|
         yield(stub)
       end
     end
@@ -835,6 +853,7 @@ module Ocran
                       enable_compression: @option.enable_compression?,
                       gui_mode: false,
                       icon_path: nil,
+                      stub_path: cosmo_stub_path,
                       &to_proc) => builder
 
       if @option.icon_filename
@@ -884,6 +903,7 @@ module Ocran
                       enable_compression: @option.enable_compression?,
                       gui_mode: @option.windowed?,
                       icon_path: @option.icon_filename,
+                      stub_path: cosmo_stub_path,
                       &to_proc) => builder
       say "Finished building #{@option.output_executable} (#{@option.output_executable.size} bytes)"
       say "After decompression, the data will expand to #{builder.data_size} bytes."

--- a/lib/ocran/option.rb
+++ b/lib/ocran/option.rb
@@ -16,6 +16,7 @@ module Ocran
         :macosx_bundle => nil,
         :macosx_bundle? => false,
         :chdir_before? => false,
+        :cosmo_cc => nil,
         :enable_compression? => true,
         :enable_debug_extract? => false,
         :enable_debug_mode? => false,
@@ -107,6 +108,15 @@ Executable options:
 --rubyopt <str>    Set the RUBYOPT environment variable when running the executable
 --debug            Executable will be verbose.
 --debug-extract    Executable will unpack to local dir and not delete after.
+
+Experimental options:
+
+--cosmo <path>     Build the launcher stub from source with the given
+                   Cosmopolitan toolchain (cosmocc) and package with the
+                   resulting Actually Portable Executable (APE) stub.
+                   <path> is the cosmocc executable or its install dir.
+                   Console-only; output defaults to <scriptname>.com.
+                   (Alias: --cosmo-toolchain)
 EOF
     end
 
@@ -155,6 +165,9 @@ EOF
           @options[:icon_filename] = Pathname.new(path).expand_path
         when "--rubyopt"
           @options[:rubyopt] = argv.shift
+        when "--cosmo", "--cosmo-toolchain"
+          require_relative "cosmo_toolchain"
+          @options[:cosmo_cc] = CosmoToolchain.resolve_cc(argv.shift)
         when "--gemfile"
           path = argv.shift
           raise "Gemfile #{path} not found" unless path && File.exist?(path)
@@ -219,8 +232,15 @@ EOF
           executable = script
           # If debug mode is enabled, append "-debug" to the filename
           executable = executable.append_to_filename("-debug") if enable_debug_mode?
-          # Build output files are created in the current directory
-          ext = Gem.win_platform? ? ".exe" : ""
+          # Build output files are created in the current directory.
+          # APE binaries built with cosmocc conventionally use .com.
+          ext = if cosmo_cc
+                  ".com"
+                elsif Gem.win_platform?
+                  ".exe"
+                else
+                  ""
+                end
           executable.basename.sub_ext(ext).expand_path
         end
 
@@ -253,6 +273,16 @@ EOF
         raise "--output-dir and --output-zip cannot be used together"
       end
 
+      if cosmo_cc
+        if Gem.win_platform?
+          raise "--cosmo is not supported when building on Windows (build the APE stub on a Linux/macOS host)"
+        end
+
+        if force_windows?
+          raise "--windows cannot be used with --cosmo: cosmocc has no GUI (stubw) equivalent; APE stubs are console-only"
+        end
+      end
+
       if macosx_bundle && (output_dir || output_zip || inno_setup_script)
         raise "--macosx-bundle cannot be combined with --output-dir, --output-zip, or --innosetup"
       end
@@ -271,6 +301,8 @@ EOF
     def auto_detect_dlls? = @options[__method__]
 
     def chdir_before? = @options[__method__]
+
+    def cosmo_cc = @options[__method__]
 
     def enable_compression? = @options[__method__]
 

--- a/lib/ocran/stub_builder.rb
+++ b/lib/ocran/stub_builder.rb
@@ -103,9 +103,15 @@ module Ocran
     # are installed next to the stub (pre-1.4/OCRA behavior). The directory
     # is never deleted on exit.
     #
+    # stub_path:
+    # Path to a stub binary to package with instead of the pre-built
+    # stub shipped with the gem (e.g. an APE stub freshly compiled with
+    # cosmocc, see --cosmo). When set, it takes precedence over both
+    # STUB_PATH and STUBW_PATH.
+    #
     def initialize(path, chdir_before: nil, debug_extract: nil, debug_mode: nil,
                    enable_compression: nil, gui_mode: nil, icon_path: nil,
-                   run_in_exe_dir: nil)
+                   run_in_exe_dir: nil, stub_path: nil)
       @dirs = FilePathSet.new
       @files = FilePathSet.new
       @data_size = 0
@@ -117,7 +123,9 @@ module Ocran
       output_dir = File.dirname(path)
       FileUtils.mkdir_p(output_dir) unless Dir.exist?(output_dir)
       stub_tmp = File.join(output_dir, ".ocran_stub_#{$$}_#{Time.now.to_i}")
-      stub_src = if gui_mode && WINDOWS
+      stub_src = if stub_path
+                   stub_path
+                 elsif gui_mode && WINDOWS
                    STUBW_PATH
                  else
                    STUB_PATH

--- a/ocran.gemspec
+++ b/ocran.gemspec
@@ -30,6 +30,10 @@ Gem::Specification.new do |spec|
   spec.platform = Gem::Platform::CURRENT
 
   spec.files = Dir.glob("{exe,lib,share}/**/*") +
+               # Stub C sources so the launcher stub can be rebuilt at
+               # packaging time from an installed gem (--cosmo / cosmocc).
+               Dir.glob("src/**/*.{c,h,rc,manifest,ico}") +
+               ["src/Makefile"] +
                %w[README.md LICENSE.txt CHANGELOG.txt]
   spec.bindir = "exe"
   spec.executables = Dir.glob("exe/*").map { |f| File.basename(f) }

--- a/test/test_ocra.rb
+++ b/test/test_ocra.rb
@@ -164,6 +164,67 @@ class TestOcran < Minitest::Test
     end
   end
 
+  # Locates a cosmocc toolchain for the --cosmo end-to-end test: honors
+  # the COSMOCC environment variable (cosmocc binary or toolchain dir),
+  # otherwise looks for cosmocc in PATH. Returns nil if unavailable.
+  def find_cosmocc
+    env = ENV["COSMOCC"]
+    return env if env && !env.empty? && File.exist?(env)
+    path = `which cosmocc 2>/dev/null`.chomp
+    path.empty? ? nil : path
+  end
+
+  # --cosmo toolchain path resolution: accepts the cosmocc binary itself,
+  # the toolchain root (containing bin/cosmocc), or the bin directory,
+  # and raises clear errors otherwise. Runs without a real toolchain.
+  def test_cosmo_toolchain_resolution
+    require_relative "../lib/ocran/cosmo_toolchain"
+    with_tmpdir do
+      mkdir_p "toolchain/bin"
+      cc = File.expand_path("toolchain/bin/cosmocc")
+      File.write(cc, "#!/bin/sh\n")
+      File.chmod(0755, cc)
+
+      assert_equal cc, Ocran::CosmoToolchain.resolve_cc("toolchain")
+      assert_equal cc, Ocran::CosmoToolchain.resolve_cc("toolchain/bin")
+      assert_equal cc, Ocran::CosmoToolchain.resolve_cc(cc)
+
+      err = assert_raises(RuntimeError) { Ocran::CosmoToolchain.resolve_cc("no/such/path") }
+      assert_match(/cosmocc not found/, err.message)
+
+      err = assert_raises(RuntimeError) { Ocran::CosmoToolchain.resolve_cc(nil) }
+      assert_match(/--cosmo requires a path/, err.message)
+
+      unless Gem.win_platform?
+        File.chmod(0644, cc)
+        err = assert_raises(RuntimeError) { Ocran::CosmoToolchain.resolve_cc("toolchain") }
+        assert_match(/not executable/, err.message)
+      end
+    end
+  end
+
+  # End-to-end --cosmo build: compiles the stub from src/ with cosmocc at
+  # packaging time, packages helloworld with the resulting APE stub
+  # (default output extension .com), and runs the binary. Skipped unless
+  # a cosmocc toolchain is available (COSMOCC env var or cosmocc in PATH).
+  def test_cosmo_helloworld
+    skip "--cosmo requires a POSIX build host" if Gem.win_platform?
+    cosmocc = find_cosmocc
+    skip "cosmocc not found (set COSMOCC or add cosmocc to PATH)" unless cosmocc
+
+    with_fixture 'helloworld' do
+      assert system("ruby", ocran, "helloworld.rb", *DefaultArgs, "--cosmo", cosmocc)
+      assert File.exist?("helloworld.com")
+      # APE binaries start with the "MZqFpD" MZ/shell polyglot magic
+      assert_equal "MZqFpD", File.binread("helloworld.com", 6)
+      pristine_env "helloworld.com" do
+        # Invoke through the shell: an APE bootstraps itself via its
+        # shell-script header on hosts without APE binfmt support.
+        assert system("./helloworld.com")
+      end
+    end
+  end
+
   # Should be able to build executables with LZMA compression
   def test_lzma
     with_fixture 'helloworld' do


### PR DESCRIPTION
Stacked on #47 (base branch is `fix/issue-26-cosmocc-stub`); continues #26.

## What this adds
A new experimental option `--cosmo <path>` (alias `--cosmo-toolchain`) that takes the location of a cosmocc toolchain and **builds the launcher stub from `src/` at packaging time**, then packages the app with the resulting Actually Portable Executable stub — no pre-built cosmo stub needs to ship.

- `<path>` accepts the `cosmocc` executable, the toolchain root (unpacked cosmocc.zip), or its `bin` dir; validated at option-parse time with clear errors.
- Compilation runs `make stub CC=<cosmocc>` on a clean temp copy of `src/` (stale native objects from a dev checkout can never be linked); compiler output is surfaced verbatim on failure.
- Built stubs are cached in `~/.cache/ocran` (XDG-aware), keyed on SHA-256 of the toolchain (path+mtime+size) and all `src/` contents; memoized per run so wrapper/bundle builds compile at most once.
- Default output extension becomes `.com` for cosmo builds (APE convention); explicit `--output` is honored verbatim.
- `--windows` + `--cosmo` errors (cosmo has no stubw/GUI equivalent); Windows build hosts are rejected for v1 (the Makefile cosmo path is POSIX-only).
- The binary platform gem now ships `src/` (the source gem already did), so `--cosmo` works from an installed gem.

## Testing (real toolchain, cosmocc 14.1.0)
- `test_cosmo_toolchain_resolution`: 12 assertions on the three path forms + error cases (no toolchain required).
- `test_cosmo_helloworld` (skips when cosmocc absent): builds `helloworld.com`, asserts the `MZqFpD` APE magic, runs it in a pristine env. Verified both cache-cold and cache-warm.
- Manual: exit-code propagation through the APE stub (exit 42 observed), toolchain-dir/binary/bin-dir forms, bad-path and `--windows` conflict errors.
- Regression slice with the normal pre-built stub path: 5 runs, 20 assertions, 0 failures.

## Caveats
The packaged Ruby runtime is still host-native — the APE property applies to the launcher stub for now. Making the payload itself portable (cosmo-built Ruby) is the next phase; see `docs/cosmocc-port-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)