### PR TITLE
Fix red master: keep the tests' Bundler runs out of OCRAN's own lockfile

### DIFF
--- a/.github/check-clean-tree.sh
+++ b/.github/check-clean-tree.sh
@@ -8,15 +8,20 @@
 # runs `bundle exec`, with a frozen-mode error that names neither the test
 # that did it nor the fact that a test did it at all.
 #
-# Untracked files are ignored on purpose: `bundle install` populates
-# vendor/bundle, and builds leave stubs and packed executables behind.
+# Untracked files are ignored on purpose: the builds leave stubs and packed
+# executables behind. So are vendor/ and .bundle/, which are checked in but
+# describe the machine rather than the project: `bundle install` rewrites the
+# vendored bundle (shebangs and line endings differ per platform) and
+# ruby/setup-ruby writes `deployment: true` into the config, both before
+# anything of ours has run.
 set -eu
 
-dirty=$(git status --porcelain --untracked-files=no)
+dirty=$(git status --porcelain --untracked-files=no \
+        -- . ':(exclude)vendor' ':(exclude).bundle')
 if [ -n "$dirty" ]; then
     echo "::error::the test run modified files under version control"
     echo "$dirty"
-    git diff --stat
+    git diff --stat -- . ':(exclude)vendor' ':(exclude).bundle'
     exit 1
 fi
 

--- a/.github/check-clean-tree.sh
+++ b/.github/check-clean-tree.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Fails when the test run modified a file under version control.
+#
+# The tests run Bundler against fixture Gemfiles. A Bundler that has been
+# pointed at the wrong lockfile - `bundle exec` exports BUNDLE_LOCKFILE, and
+# children inherit it - rewrites OCRAN's own Gemfile.lock with a fixture's
+# dependencies. The test suite stays green; what dies is the next step that
+# runs `bundle exec`, with a frozen-mode error that names neither the test
+# that did it nor the fact that a test did it at all.
+#
+# Untracked files are ignored on purpose: `bundle install` populates
+# vendor/bundle, and builds leave stubs and packed executables behind.
+set -eu
+
+dirty=$(git status --porcelain --untracked-files=no)
+if [ -n "$dirty" ]; then
+    echo "::error::the test run modified files under version control"
+    echo "$dirty"
+    git diff --stat
+    exit 1
+fi
+
+echo "working tree clean"

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -2,7 +2,12 @@ name: Run Tests
 on:
   push:
     branches:
-      - '*'
+      # '**' and not '*': a single star stops at a slash, so every branch
+      # named the way this project names them - fix/..., feat/... - was
+      # never tested until it landed on master, which is where the last two
+      # merges turned red.
+      - '**'
+  workflow_dispatch:
 jobs:
   run-tests-linux:
     strategy:

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -32,6 +32,10 @@ jobs:
           bundle exec rake build
           bundle exec rake test
 
+      - name: Fail if the test run left the working tree dirty
+        shell: bash
+        run: bash .github/check-clean-tree.sh
+
       - name: Build zlib fixture for cross-distro test
         env:
           OCRAN_DEBUG: "0"
@@ -65,6 +69,10 @@ jobs:
         run: |
           bundle exec rake build
           bundle exec rake test
+
+      - name: Fail if the test run left the working tree dirty
+        shell: bash
+        run: bash .github/check-clean-tree.sh
 
       - name: Build zlib fixture for cross-system test
         run: ruby -Ilib exe/ocran test/fixtures/zlib/zlib.rb --output zlib_packed
@@ -194,6 +202,10 @@ jobs:
         run: |
           bundle exec rake build
           bundle exec rake test
+
+      - name: Fail if the test run left the working tree dirty
+        shell: bash
+        run: bash .github/check-clean-tree.sh
 
       - name: Build zlib fixture for portability test
         run: bundle exec ruby -Ilib exe/ocran test/fixtures/zlib/zlib.rb --output zlib_packed.exe

--- a/test/test_ocra.rb
+++ b/test/test_ocra.rb
@@ -41,6 +41,24 @@ class TestOcran < Minitest::Test
   # Path to test fixtures.
   FixturePath = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures'))
 
+  # OCRAN's own lockfile and its content before any test ran. The tests run
+  # Bundler against fixture Gemfiles, and a Bundler that has been pointed at
+  # the wrong lockfile rewrites this one instead of the fixture's. Nothing in
+  # the test run notices - the damage surfaces in whatever runs `bundle exec`
+  # afterwards, which in CI is a build step several minutes later.
+  OwnLockfile = File.join(OcranRoot, "Gemfile.lock")
+  OwnLockfileContent = File.exist?(OwnLockfile) ? File.binread(OwnLockfile) : nil
+
+  # Asserts that running Bundler has not damaged OCRAN's own bundle.
+  def assert_own_lockfile_intact(what)
+    return if OwnLockfileContent.nil?
+
+    assert OwnLockfileContent == File.binread(OwnLockfile),
+           "#{what} rewrote OCRAN's own lockfile (#{OwnLockfile}). " \
+           "Bundler was run with a foreign Gemfile but the lockfile of " \
+           "this bundle; restore it with `git checkout Gemfile.lock`."
+  end
+
   # Create a pristine environment to test built executables. Files are
   # copied and the PATH environment is set to the minimal. Yields to
   # the block, then cleans up.
@@ -134,10 +152,23 @@ class TestOcran < Minitest::Test
   # The environment `bundle exec` sets for the given Gemfile, or nil when
   # that bundle cannot be used here (Bundler missing, gems not installed),
   # so callers can skip rather than fail.
+  #
+  # BUNDLE_LOCKFILE is cleared rather than left alone. `bundle exec` exports
+  # the absolute path of the lockfile it used, and this suite itself runs
+  # under `bundle exec rake test`, so every child inherits OCRAN's own
+  # Gemfile.lock by name. Bundler believes that variable over the Gemfile it
+  # is handed, so resolving a fixture Gemfile here would write the fixture's
+  # dependencies into OCRAN's lockfile - leaving the tests green and every
+  # later `bundle exec` in the same job dead in frozen mode. Unset, Bundler
+  # puts the lockfile next to the Gemfile, which for a fixture means inside
+  # the temporary directory it was copied to.
   def bundle_exec_env(gemfile)
     dump = 'ENV.each { |name, value| puts "#{name}=#{value}" }'
-    output, status = capture_system({ "BUNDLE_GEMFILE" => gemfile.to_s },
+    output, status = capture_system({ "BUNDLE_GEMFILE" => gemfile.to_s,
+                                      "BUNDLE_LOCKFILE" => nil },
                                     "bundle", "exec", "ruby", "-e", dump)
+    assert_own_lockfile_intact("bundle exec against #{gemfile}")
+
     return nil unless status&.success?
 
     env = output.lines.filter_map { |line|


### PR DESCRIPTION
`master` is red on Windows only, in the step **Build zlib fixture for portability test**:

```
You have deleted from the Gemfile:
* mylocal
... the lockfile can't be updated because frozen mode is set
```

## Root cause

`bundle exec` exports `BUNDLE_LOCKFILE` holding the absolute path of the lockfile it used. The test suite runs under `bundle exec rake test`, so every child process it spawns inherits `BUNDLE_LOCKFILE=<repo>/Gemfile.lock`.

`bundle_exec_env` (added in #54) runs `bundle exec ruby -e ...` with `BUNDLE_GEMFILE` pointed at a fixture Gemfile — for `test_bundle_exec_own_bundle_is_not_warned_about`, `test/fixtures/localgem/Gemfile`, copied to a tmpdir. Bundler believes `BUNDLE_LOCKFILE` over the Gemfile it was handed, so it resolved the fixture and wrote the result — `PATH remote: mylocal` and nothing else — into **OCRAN's own `Gemfile.lock`**, not the fixture's.

Every platform did this. Only Windows noticed: its post-test zlib step runs `bundle exec ruby ...`, and `ruby/setup-ruby` has put `deployment: true` in `.bundle/config`, so Bundler refuses the rewritten lockfile. Linux and macOS run that step under plain `ruby` and stayed green while carrying the same damage.

(The repo-local `deployment: true` never applied to the offending call itself: with `BUNDLE_GEMFILE` in a tmpdir, `.bundle/config` is out of Bundler's root, so nothing stopped the write.)

## Fix

- `bundle_exec_env` clears `BUNDLE_LOCKFILE`, which puts the lockfile back where Bundler would put it unaided — next to the Gemfile, i.e. inside the temporary copy that is deleted with the rest of the fixture. The tests still run real Bundler against real fixture Gemfiles; nothing is weakened.
- Every such Bundler run is followed by an assertion that OCRAN's lockfile still has its pre-run content, so the next variant of this names itself instead of surfacing three steps later.
- CI fails right after the test step if the run modified a tracked file (`vendor/` and `.bundle/` excluded — both are checked in but rewritten by `bundle install` and `setup-ruby` before any test runs).
- `branches: ['*']` never matched `fix/...` or `feat/...`: a single star stops at a slash. Every branch here was merged untested, which is how the last two merges reached master red. Now `'**'`, plus `workflow_dispatch`.

## Verification

Windows on this branch, run https://github.com/Largo/ocran/actions/runs/31359567122 — `run-tests-windows` 3.3 / 3.4 / 4.0 and all three `test-windows-portability` jobs green. Linux and macOS jobs were still waiting for runners at the time of writing; locally, `bundle exec rake test` leaves the tree clean and shows only this box's known failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)